### PR TITLE
docs: Add tagging-consistency.md to improve O-RAN-SC documentation

### DIFF
--- a/docs/tagging-consistency.md
+++ b/docs/tagging-consistency.md
@@ -1,0 +1,48 @@
+# Tagging Consistency Report
+
+This document summarizes how release tags are used and referenced in the O-RAN PTI O2 repository.
+
+## Tag List
+
+Current Git tags:
+- 1.0.0
+- 2.0.0
+- 2.0.1
+- ...
+- 2.2.0
+- k-release
+- l-release
+
+## Locations Where Tags Are Referenced
+
+### Tag: `2.2.0`
+
+Referenced in:
+- `releases/release-2.2.0.yaml` (version and container_release_tag)
+- `docs/release-notes.rst` (release notes for version 2.2.0)
+- `docs/installation-guide.rst` (Docker image reference)
+- Git metadata
+
+### Observations
+
+- Tags are consistently reflected in `release-*.yaml`, release notes, and installation guide.
+- Release notes match the tag versions and dates.
+- Docker container images use matching tags.
+
+## Tag Update Checklist
+
+When adding a new release tag, ensure consistency across all relevant files:
+
+- `releases/release-<version>.yaml` (e.g., release-2.2.0.yaml)
+- `container-tag.yaml` (used in CI for Docker image tagging)
+- `docs/release-notes.rst` (formal release notes)
+- `docs/installation-guide.rst` (image versions in deployment steps)
+
+Use consistent naming conventions across tags (e.g., semantic versioning like `2.2.1`, or named releases like `l-release`).
+
+
+
+---
+
+Prepared by: Alisha Mahmood  
+Date: 2025-08-04


### PR DESCRIPTION
This PR tries to solve the issue of Tagging consistency. I've created docs/tagging-consistency.md which reports the current Git tag usage and ensures consistency across release files, documentation, and Docker image references for the O-RAN PTI O2 project. Also verified the documentation build using tox -e docs

<img width="1920" height="1020" alt="Screenshot 2025-08-04 163107" src="https://github.com/user-attachments/assets/bac715bf-c769-465f-957c-3797d78ae793" />

<img width="1919" height="1018" alt="Screenshot 2025-08-04 155052" src="https://github.com/user-attachments/assets/db30242d-b8dc-48ac-be75-4caa1cc71b45" />


<img width="1920" height="1020" alt="Screenshot 2025-08-04 163006" src="https://github.com/user-attachments/assets/bd9d5625-aa54-4bc4-aeba-1ee7ce3dd4e3" />
